### PR TITLE
Problem on inserting/updating/selecting null values

### DIFF
--- a/PtcQueryBuilder.php
+++ b/PtcQueryBuilder.php
@@ -633,16 +633,15 @@
 			if ( is_numeric( $pos ) ) { $pos = ( $pos + 1 ); }
 			if ( is_null( $type ) ) 
 			{
-				switch ( $value ) 
-				{
-					case is_null( $value ): $type = \PDO::PARAM_NULL;
-					break;
-					case is_int( $value ): $type = \PDO::PARAM_INT;
-					break;
-					case is_bool( $value ): $type = \PDO::PARAM_BOOL;
-					break;
-					default: $type = \PDO::PARAM_STR;
-				}
+			    if (is_null($value)) {
+				$type = \PDO::PARAM_NULL;
+			    } elseif (is_int($value)) {
+				$type = \PDO::PARAM_INT;
+			    } elseif (is_bool($value)) {
+				$type = \PDO::PARAM_BOOL;
+			    } else {
+				$type = \PDO::PARAM_STR;
+			    }
 			}
 			$this->_query->bindValue( $pos , $value , $type );
 		}

--- a/PtcQueryBuilder.php
+++ b/PtcQueryBuilder.php
@@ -635,11 +635,11 @@
 			{
 				switch ( $value ) 
 				{
+					case is_null( $value ): $type = \PDO::PARAM_NULL;
+					break;
 					case is_int( $value ): $type = \PDO::PARAM_INT;
 					break;
 					case is_bool( $value ): $type = \PDO::PARAM_BOOL;
-					break;
-					case is_null( $value ): $type = \PDO::PARAM_NULL;
 					break;
 					default: $type = \PDO::PARAM_STR;
 				}


### PR DESCRIPTION
Hi, the method that parse the value to be selected/updated/inserted has a problem: if i try to insert a value of null it parses it to 0, found the problem, here's the solution:

the method "_bind" should change from this:

```php
  /**
     * Binds values to the query
     * @param	mixed		$pos		the param position if numeric
     * @param	mixed		$value		the value to bind the place holder to
     * @param	contants	$type		a pdo constant to bind values
     */
    protected function _bind($pos, $value, $type = null)
    {
        if (is_numeric($pos)) {
            $pos = ($pos + 1);
        }
        if (is_null($type)) {
            switch ($value) {
                case is_int($value):
                    $type = \PDO::PARAM_INT;
                    break;
                case is_bool($value):
                    $type = \PDO::PARAM_BOOL;
                    break;
                case is_null($value):
                    $type = \PDO::PARAM_NULL;
                    break;
                default:
                    $type = \PDO::PARAM_STR;
            }
        }
        $this->_query->bindValue($pos, $value, $type);
    }
```
to this:

```php
    /**
     * Binds values to the query
     * @param	mixed		$pos		the param position if numeric
     * @param	mixed		$value		the value to bind the place holder to
     * @param	contants	$type		a pdo constant to bind values
     */
    protected function _bind($pos, $value, $type = null)
    {
        if (is_numeric($pos)) {
            $pos = ($pos + 1);
        }
        if (is_null($type)) {
            if (is_null($value)) {
                $type = \PDO::PARAM_NULL;
            } elseif (is_int($value)) {
                $type = \PDO::PARAM_INT;
            } elseif (is_bool($value)) {
                $type = \PDO::PARAM_BOOL;
            } else {
                $type = \PDO::PARAM_STR;
            }
        }
        $this->_query->bindValue($pos, $value, $type);
    }
```

that means that the switch evaluates the "0" as true (do not know why), entering always on the first condition... so i changed it into a if-elseif and everything seems to work